### PR TITLE
fix: load requirements from non-standard location

### DIFF
--- a/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -50,6 +50,11 @@ class SerenityPlugin implements Plugin<Project> {
                 if (project.serenity.requirementsBaseDir) {
                     System.properties['serenity.test.requirements.basedir'] = project.serenity.requirementsBaseDir
                 }
+                if (project.serenity.requirementsDir) {
+                    SystemPropertiesConfiguration configuration = (SystemPropertiesConfiguration) Injectors.getInjector().getProvider(Configuration.class).get()
+                    configuration.getEnvironmentVariables().setProperty('serenity.requirements.dir', project.serenity.requirementsDir)
+                }
+
                 def reporter
                 if (project.serenity.testRoot != null) {
                     def requirements = new DefaultRequirements(project.serenity.testRoot)

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPluginExtension.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPluginExtension.groovy
@@ -13,6 +13,7 @@ class SerenityPluginExtension {
     String jiraProject
     String sourceDirectory = outputDirectory
     String requirementsBaseDir
+    String requirementsDir
     String testRoot
     boolean generateOutcomes
     List<String> reports


### PR DESCRIPTION
specify `requirementsDir` Gradle property to set `serenity.requirements.dir`
system property

this fixes https://github.com/serenity-bdd/serenity-cucumber6/issues/14