### PR TITLE
Fix configuration of depencencies between tasks (#7)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ task tagNewVersion() {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.4.2'
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -13,6 +13,7 @@ import net.thucydides.core.webdriver.Configuration
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -27,6 +28,7 @@ class SerenityPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         updateSystemPath(project)
+        project.getPluginManager().apply(JavaPlugin.class)
         project.extensions.create("serenity", SerenityPluginExtension)
         project.task('aggregate') {
             group = 'Serenity BDD'
@@ -168,15 +170,16 @@ class SerenityPlugin implements Plugin<Project> {
 
         project.tasks.checkOutcomes.mustRunAfter project.tasks.aggregate
 
-        // TODO: These bits no longer works in recent versions of Gradle, not sure why.
-//        project.tasks.aggregate.mustRunAfter project.tasks.test
-//
-//        project.tasks.clean {
-//            it.dependsOn 'clearReports'
-//        }
-//        project.tasks.check {
-//            it.dependsOn 'checkOutcomes'
-//        }
+        project.tasks.test {
+            it.finalizedBy 'aggregate'
+        }
+
+        project.tasks.clean {
+            it.dependsOn 'clearReports'
+        }
+        project.tasks.check {
+            it.dependsOn 'checkOutcomes'
+        }
     }
 
     static Path absolutePathOf(Path path) {

--- a/src/main/resources/META-INF/gradle-plugins/net.serenity-bdd.aggregator.properties
+++ b/src/main/resources/META-INF/gradle-plugins/net.serenity-bdd.aggregator.properties
@@ -1,1 +1,0 @@
-implementation-class=net.serenitybdd.plugins.gradle.SerenityPlugin


### PR DESCRIPTION
#### Summary of this PR
Upgrade gradle version from 7.0.2 to 7.4.2
Delete redundant gradle plugin properties file
Fix configuration of dependencies between tasks (fixes #7)

#### Intended effect
`clearReports` is run before `clean`
`checkOutcomes` is run before `check`
`aggregate` is always run after `test`

#### How should this be manually tested?
```
./gradle clean test
```
#### Side effects
`aggregate` is *always* executed after `test`
#### Documentation
N/A
#### Relevant tickets
#7 
#### Screenshots (if appropriate)
N/A