### PR TITLE
Make plugin compatible with configuration-cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,11 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
 //signing {
 //    def signingKey = findProperty("signingKey")
 //    def signingPassword = findProperty("signingPassword")
@@ -103,6 +108,7 @@ test {
     exclude '**/samples/**'
     exclude '**/*Sample*'
     maxParallelForks = Runtime.runtime.availableProcessors() * 4
+    useJUnitPlatform {}
 }
 
 
@@ -121,6 +127,10 @@ dependencies {
     implementation("net.serenity-bdd:serenity-core:${serenityCoreVersion}")
     implementation("net.serenity-bdd:serenity-model:${serenityCoreVersion}")
     implementation("net.serenity-bdd:serenity-junit:${serenityCoreVersion}")
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }
 
 jar {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/AggregateTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/AggregateTask.groovy
@@ -1,62 +1,94 @@
 package net.serenitybdd.plugins.gradle
 
-import net.serenitybdd.model.di.ModelInfrastructure
-import net.thucydides.core.reports.html.HtmlAggregateStoryReporter
 import net.serenitybdd.core.di.SerenityInfrastructure
+import net.thucydides.core.reports.html.HtmlAggregateStoryReporter
 import net.thucydides.model.configuration.SystemPropertiesConfiguration
 import net.thucydides.model.reports.ResultChecker
-import net.thucydides.model.requirements.DefaultRequirements;
+import net.thucydides.model.requirements.DefaultRequirements
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
+import javax.inject.Inject
 import java.nio.file.Path
 
-class AggregateTask extends SerenityAbstractTask {
+abstract class AggregateTask extends SerenityAbstractTask {
+
+    @Input
+    abstract Property<String> getProjectKey()
+
+    @Optional @Input
+    abstract Property<String> getTestRoot()
+
+    @Optional @Input
+    abstract Property<String> getRequirementsBaseDir()
+
+    @Optional @Input
+    abstract Property<String> getRequirementsDir()
+
+    @Optional @Input
+    abstract Property<String> getIssueTrackerUrl()
+
+    @Optional @Input
+    abstract Property<String> getJiraUrl()
+
+    @Optional @Input
+    abstract Property<String> getJiraProject()
+
+    @Input
+    abstract Property<Boolean> getGenerateOutcomes()
+
+    @OutputDirectory
+    abstract Path reportDirectory;
+
+    @Inject
+    AggregateTask(ProjectLayout layout) {
+        super(layout)
+    }
+
     @TaskAction
     void aggregate() {
-        updateProperties(project)
-        Path reportDirectory = SerenityAbstractTask.prepareReportDirectory(project)
-
-        if (!project.serenity.projectKey) {
-            project.serenity.projectKey = project.name
-        }
+        updateSystemPath()
+        def testRoot = getTestRoot().getOrNull()
         logger.lifecycle("Generating Serenity Reports")
-        String testRoot = project.serenity.testRoot
 
-        if (project.serenity.testRoot) {
-            logger.lifecycle("  - Test Root: ${project.serenity.testRoot}")
-            System.properties['serenity.test.root'] = project.serenity.testRoot
+        if (testRoot) {
+            logger.lifecycle("  - Test Root: ${testRoot}")
+            System.properties['serenity.test.root'] = testRoot
         }
         URI mainReportPath = absolutePathOf(reportDirectory.resolve("index.html")).toUri()
+        def requirementsBaseDir = getRequirementsBaseDir().getOrNull()
         logger.lifecycle("  - Main report: $mainReportPath")
-        logger.lifecycle("      - Test Root: ${project.serenity.testRoot}")
-        logger.lifecycle("      - Requirements base directory: ${project.serenity.requirementsBaseDir}")
+        logger.lifecycle("      - Test Root: ${testRoot}")
+        logger.lifecycle("      - Requirements base directory: ${requirementsBaseDir}")
 
-        System.properties['serenity.project.key'] = project.serenity.projectKey
-        if (project.serenity.requirementsBaseDir) {
-            System.properties['serenity.test.requirements.basedir'] = project.serenity.requirementsBaseDir
+        System.properties['serenity.project.key'] = getProjectKey()
+        if (requirementsBaseDir) {
+            System.properties['serenity.test.requirements.basedir'] = requirementsBaseDir
         }
-        if (project.serenity.requirementsDir) {
+        def requirementsDir = getRequirementsDir().getOrNull()
+        if (requirementsDir) {
 
             SystemPropertiesConfiguration configuration = SerenityInfrastructure.getConfiguration()
-            configuration.getEnvironmentVariables().setProperty('serenity.requirements.dir', project.serenity.requirementsDir)
+            configuration.getEnvironmentVariables().setProperty('serenity.requirements.dir', requirementsDir)
         }
 
-        def reporter
+        def requirements = (testRoot) ? new DefaultRequirements(testRoot) : new DefaultRequirements()
 
-        def requirements = (project.serenity.testRoot) ? new DefaultRequirements(project.serenity.testRoot) : new DefaultRequirements()
-
-        // Set the project directory for use in the reporting tasks
-        ModelInfrastructure.configuration.setProjectDirectory(project.projectDir.toPath())
-
-        reporter = new HtmlAggregateStoryReporter(project.serenity.projectKey, requirements)
+        def reporter = new HtmlAggregateStoryReporter(getProjectKey().get(), requirements)
         reporter.outputDirectory = reportDirectory.toFile()
-        reporter.testRoot = project.serenity.testRoot
-        reporter.projectDirectory = project.projectDir.absolutePath
-        reporter.issueTrackerUrl = project.serenity.issueTrackerUrl
-        reporter.jiraUrl = project.serenity.jiraUrl
-        reporter.jiraProject = project.serenity.jiraProject
+        reporter.testRoot = testRoot
+        reporter.projectDirectory = layout.projectDirectory.asFile.absolutePath
+        reporter.issueTrackerUrl = getIssueTrackerUrl().getOrNull()
+        reporter.jiraUrl = getJiraUrl().getOrNull()
+        reporter.jiraProject = getJiraProject().getOrNull()
 
-        reporter.setGenerateTestOutcomeReports();
+        if (getGenerateOutcomes().get()) {
+            reporter.setGenerateTestOutcomeReports();
+        }
         reporter.generateReportsForTestResultsFrom(reporter.outputDirectory)
         new ResultChecker(reporter.outputDirectory).checkTestResults();
     }

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/CheckOutcomesTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/CheckOutcomesTask.groovy
@@ -1,27 +1,35 @@
 package net.serenitybdd.plugins.gradle
 
 import net.thucydides.model.reports.ResultChecker
-import org.gradle.api.file.FileCollection
-import org.gradle.api.tasks.InputFiles
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
+import javax.inject.Inject
+import java.nio.file.Files
 import java.nio.file.Path
 
-class CheckOutcomesTask extends SerenityAbstractTask {
-    @InputFiles
-    FileCollection getReportFiles() {
-        Path reportDirectory = SerenityAbstractTask.prepareReportDirectory(project)
+abstract class CheckOutcomesTask extends SerenityAbstractTask {
 
-        return project.fileTree(reportDirectory)
+    @InputDirectory
+    abstract Path reportDirectory;
+
+    @Input @Optional
+    abstract Property<String> getProjectKey();
+
+    @Inject
+    CheckOutcomesTask(ProjectLayout layout) {
+        super(layout)
     }
 
     @TaskAction
     void checkOutcomes() {
-        Path reportDirectory = SerenityAbstractTask.prepareReportDirectory(project)
-
-        SerenityAbstractTask.updateProperties(project)
-        logger.lifecycle("Checking serenity results for ${project.serenity.projectKey} in directory $reportDirectory")
-        if (reportDirectory.toFile().exists()) {
+        updateSystemPath()
+        logger.lifecycle("Checking serenity results for ${getProjectKey().get()} in directory $reportDirectory")
+        if (Files.exists(reportDirectory)) {
             def checker = new ResultChecker(reportDirectory.toFile())
             checker.checkTestResults()
         }

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/ClearHistoryTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/ClearHistoryTask.groovy
@@ -1,15 +1,25 @@
 package net.serenitybdd.plugins.gradle
 
+import org.apache.commons.io.FileUtils
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
-import java.nio.file.Files
+import javax.inject.Inject
+import java.nio.file.Path
 
 class ClearHistoryTask extends SerenityAbstractTask {
 
+    @OutputDirectory
+    abstract Path historyDirectory;
+
+    @Inject
+    ClearHistoryTask(ProjectLayout layout) {
+        super(layout)
+    }
+
     @TaskAction
     void clearHistory() {
-        SerenityAbstractTask.updateProperties(project)
-        def historyDirectory = SerenityAbstractTask.prepareHistoryDirectory(project)
-        Files.delete(historyDirectory)
+        FileUtils.deleteDirectory(historyDirectory.toFile())
     }
 }

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/ClearReportsTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/ClearReportsTask.groovy
@@ -1,14 +1,25 @@
 package net.serenitybdd.plugins.gradle
 
 import org.apache.commons.io.FileUtils
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
-class ClearReportsTask extends SerenityAbstractTask {
+import javax.inject.Inject
+import java.nio.file.Path
+
+abstract class ClearReportsTask extends SerenityAbstractTask {
+
+    @OutputDirectory
+    abstract Path reportDirectory;
+
+    @Inject
+    ClearReportsTask(ProjectLayout layout) {
+        super(layout)
+    }
 
     @TaskAction
     void clearReports() {
-        SerenityAbstractTask.updateProperties(project)
-        def reportDirectory = SerenityAbstractTask.prepareReportDirectory(project)
         FileUtils.deleteDirectory(reportDirectory.toFile())
     }
 

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/HistoryTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/HistoryTask.groovy
@@ -1,18 +1,38 @@
 package net.serenitybdd.plugins.gradle
 
 import net.serenitybdd.model.history.FileSystemTestOutcomeSummaryRecorder
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
-class HistoryTask extends SerenityAbstractTask {
+import javax.inject.Inject
+import java.nio.file.Path
+
+abstract class HistoryTask extends SerenityAbstractTask {
+
+    @InputDirectory
+    abstract Path sourceDirectory;
+
+    @Input
+    abstract Property<Boolean> getDeletePreviousHistory()
+
+    @OutputDirectory
+    abstract Path historyDirectory;
+
+    @Inject
+    HistoryTask(ProjectLayout layout) {
+        super(layout)
+    }
 
     @TaskAction
     void history() {
-        SerenityAbstractTask.updateProperties(project)
-        def historyDirectory = SerenityAbstractTask.prepareHistoryDirectory(project)
-
+        updateSystemPath()
         new FileSystemTestOutcomeSummaryRecorder(historyDirectory,
-                SerenityAbstractTask.deletePreviousHistory())
-                .recordOutcomeSummariesFrom(project.serenity.sourceDirectory);
+                getDeletePreviousHistory().get())
+                .recordOutcomeSummariesFrom(sourceDirectory);
 
     }
 }

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/ReportTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/ReportTask.groovy
@@ -3,34 +3,56 @@ package net.serenitybdd.plugins.gradle
 import net.thucydides.core.reports.ExtendedReport
 import net.thucydides.core.reports.ExtendedReports
 import net.thucydides.model.reports.ResultChecker
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
-class ReportTask extends SerenityAbstractTask {
+import javax.inject.Inject
+import java.nio.file.Path
+
+abstract class ReportTask extends SerenityAbstractTask {
+
+    @Input
+    abstract Property<String> getProjectKey()
+
+    @Optional @Input
+    abstract Property<String> getRequirementsBaseDir()
+
+    @Optional @Input
+    abstract Property<String> getTestRoot()
+
+    @Optional @Input
+    abstract ListProperty<String> getReports()
+
+    @OutputDirectory
+    abstract Path reportDirectory;
+
+    @Inject
+    ReportTask(ProjectLayout layout) {
+        super(layout)
+    }
 
     @TaskAction
     void report() {
-        SerenityAbstractTask.updateProperties(project)
-        def reportDirectory = SerenityAbstractTask.prepareReportDirectory(project)
-        if (!project.serenity.projectKey) {
-            project.serenity.projectKey = project.name
+        updateSystemPath()
+        logger.lifecycle("Generating Additional Serenity Reports for ${getProjectKey().get()} to directory $reportDirectory")
+        System.properties['serenity.project.key'] = getProjectKey()
+        if (getTestRoot().isPresent()) {
+            System.properties['serenity.test.root'] = getTestRoot().get()
         }
-
-        logger.lifecycle("Generating Additional Serenity Reports for ${project.serenity.projectKey} to directory $reportDirectory")
-        System.properties['serenity.project.key'] = project.serenity.projectKey
-        if (project.serenity.testRoot) {
-            System.properties['serenity.test.root'] = project.serenity.testRoot
+        if (getRequirementsBaseDir().isPresent()) {
+            System.properties['serenity.test.requirements.basedir'] = getRequirementsBaseDir()
         }
-        if (project.serenity.requirementsBaseDir) {
-            System.properties['serenity.test.requirements.basedir'] = project.serenity.requirementsBaseDir
-        }
-        List<String> extendedReportTypes = project.serenity.reports
-        if (extendedReportTypes) {
-            for (ExtendedReport report : ExtendedReports.named(extendedReportTypes)) {
-                report.sourceDirectory = reportDirectory
-                report.outputDirectory = reportDirectory
-                URI reportPath = SerenityAbstractTask.absolutePathOf(report.generateReport()).toUri()
-                logger.lifecycle("  - ${report.description}: ${reportPath}")
-            }
+        List<String> extendedReportTypes = getReports().getOrElse(Collections.emptyList())
+        for (ExtendedReport report : ExtendedReports.named(extendedReportTypes)) {
+            report.sourceDirectory = reportDirectory
+            report.outputDirectory = reportDirectory
+            URI reportPath = SerenityAbstractTask.absolutePathOf(report.generateReport()).toUri()
+            logger.lifecycle("  - ${report.description}: ${reportPath}")
         }
 
         ResultChecker resultChecker = new ResultChecker(reportDirectory.toFile())

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityAbstractTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityAbstractTask.groovy
@@ -1,52 +1,33 @@
 package net.serenitybdd.plugins.gradle
 
 import net.serenitybdd.core.di.SerenityInfrastructure
-import net.thucydides.model.ThucydidesSystemProperty
-import net.thucydides.model.configuration.SystemPropertiesConfiguration;
+import net.thucydides.model.configuration.SystemPropertiesConfiguration
 import org.gradle.api.DefaultTask
-import org.gradle.api.Project
+import org.gradle.api.file.ProjectLayout
 
+import javax.inject.Inject
 import java.nio.file.Path
 import java.nio.file.Paths
 
 class SerenityAbstractTask extends DefaultTask {
+
+    protected final ProjectLayout layout;
+
+    @Inject
+    SerenityAbstractTask(ProjectLayout layout) {
+        this.layout = layout
+    }
+
     static Path absolutePathOf(Path path) {
         return Paths.get(System.getProperty("user.dir")).resolve(path)
     }
 
-    static Path prepareReportDirectory(Project project) {
-        Path outputDir = Paths.get(project.serenity.outputDirectory)
-        if (!outputDir.isAbsolute()) {
-            outputDir = project.projectDir.toPath().resolve(outputDir)
-        }
-        return outputDir
-    }
-
-    static Path prepareHistoryDirectory(Project project) {
-        def outputDir = Paths.get(project.serenity.historyDirectory)
-        if (!outputDir.isAbsolute()) {
-            outputDir = project.projectDir.toPath().resolve(outputDir)
-        }
-        return outputDir
-    }
-
-    static def updateSystemPath(Project project) {
-        System.properties['project.build.directory'] = project.projectDir.getAbsolutePath()
+    void updateSystemPath() {
+        def projectBuildDirectory = layout.projectDirectory.asFile.absolutePath
+        System.properties['project.build.directory'] = projectBuildDirectory
         SystemPropertiesConfiguration configuration = SerenityInfrastructure.getConfiguration()
-        configuration.getEnvironmentVariables().setProperty('project.build.directory', project.projectDir.getAbsolutePath())
+        configuration.getEnvironmentVariables().setProperty('project.build.directory', projectBuildDirectory)
         configuration.reloadOutputDirectory()
     }
 
-    static Boolean deletePreviousHistory() {
-        SystemPropertiesConfiguration configuration = SerenityInfrastructure.getConfiguration()
-        return ThucydidesSystemProperty.DELETE_HISTORY_DIRECTORY.booleanFrom(configuration.environmentVariables, true);
-//        return configuration.environmentVariables.getPropertyAsBoolean(ThucydidesSystemProperty.DELETE_HISTORY_DIRECTORY, true)
-    }
-
-    static def updateProperties(Project project) {
-        updateSystemPath(project)
-        def config = SerenityInfrastructure.getConfiguration()
-        project.serenity.outputDirectory = config.getOutputDirectory().toPath()
-        project.serenity.sourceDirectory = config.getOutputDirectory().toPath()
-    }
 }

--- a/src/test/java/net/serenitybdd/plugins/gradle/WhenApplyingSerenityPlugin.java
+++ b/src/test/java/net/serenitybdd/plugins/gradle/WhenApplyingSerenityPlugin.java
@@ -1,0 +1,51 @@
+package net.serenitybdd.plugins.gradle;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WhenApplyingSerenityPlugin {
+
+    @TempDir
+    Path testProjectDir;
+    Path buildFile;
+
+    @BeforeEach
+    void setup() throws IOException {
+        buildFile = testProjectDir.resolve("build.gradle");
+        Files.writeString(buildFile, """
+            plugins {
+                id 'net.serenity-bdd.serenity-gradle-plugin'
+            }
+        """);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"aggregate", "reports", "checkOutcomes", "history", "clearReports", "clearHistory" })
+    void it_succesfully_runs_all_tasks_without_configuration(final String taskName) throws IOException {
+        Files.createDirectories(testProjectDir.resolve("history"));
+        Files.createDirectories(testProjectDir.resolve("target/site/serenity"));
+
+        var result = runTask(taskName);
+
+        assertEquals(SUCCESS, result.task(":" + taskName).getOutcome());
+    }
+
+    private BuildResult runTask(final String taskName) {
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments(taskName, "-i")
+                .withPluginClasspath()
+                .build();
+    }
+}
+

--- a/src/test/java/net/serenitybdd/plugins/gradle/WhenApplyingSerenityPluginWithConfigurationCache.java
+++ b/src/test/java/net/serenitybdd/plugins/gradle/WhenApplyingSerenityPluginWithConfigurationCache.java
@@ -1,0 +1,54 @@
+package net.serenitybdd.plugins.gradle;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.SKIPPED;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
+
+class WhenApplyingSerenityPluginWithConfigurationCache {
+    @TempDir
+    Path testProjectDir;
+    Path buildFile;
+
+    @BeforeEach
+    void setup() throws IOException {
+        buildFile = testProjectDir.resolve("build.gradle");
+        Files.writeString(buildFile, """
+            plugins {
+                id 'net.serenity-bdd.serenity-gradle-plugin'
+            }
+        """);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"aggregate", "reports", "checkOutcomes", "history", "clearReports", "clearHistory" })
+    void it_succesfully_runs_all_tasks_without_configuration(final String taskName) throws IOException {
+        Files.createDirectories(testProjectDir.resolve("history"));
+        Files.createDirectories(testProjectDir.resolve("target/site/serenity"));
+
+        var runner = GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withPluginClasspath();
+
+        // run tasks twice to use configuration cache
+        // see https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:testing
+        var firstResult = runner.withArguments("--configuration-cache", taskName)
+                .build();
+        assertThat(firstResult.task(":" + taskName).getOutcome()).isIn(SKIPPED, SUCCESS);
+
+        var secondResult = runner.withArguments("--configuration-cache", taskName)
+                .build();
+        assertThat(secondResult.task(":" + taskName).getOutcome()).isIn(SKIPPED, SUCCESS, UP_TO_DATE);
+    }
+
+}
+

--- a/src/test/java/net/serenitybdd/plugins/gradle/WhenRunningAggregateTask.java
+++ b/src/test/java/net/serenitybdd/plugins/gradle/WhenRunningAggregateTask.java
@@ -1,0 +1,80 @@
+package net.serenitybdd.plugins.gradle;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WhenRunningAggregateTask {
+
+    @TempDir
+    Path testProjectDir;
+    Path buildFile;
+
+    @BeforeEach
+    void setup() throws IOException {
+        buildFile = testProjectDir.resolve("build.gradle");
+        Files.writeString(buildFile, """
+            plugins {
+                id 'net.serenity-bdd.serenity-gradle-plugin'
+            }
+        """);
+    }
+
+    @Test
+    void without_configuration_logs_null_test_root() {
+        var result = runAggregateTask();
+
+        var output = result.getOutput();
+        assertThat(output).contains(" - Test Root: null");
+    }
+
+    @Test
+    void with_defined_testRoot_logs_it() throws IOException {
+        Files.writeString(buildFile, """
+            serenity {
+                testRoot = 'something'
+            }
+        """, StandardOpenOption.APPEND);
+        var result = runAggregateTask();
+
+        var output = result.getOutput();
+        assertThat(output).contains(" - Test Root: something");
+    }
+
+    @Test
+    void without_configuration_logs_null_requirements_basedir() {
+        var result = runAggregateTask();
+
+        var output = result.getOutput();
+        assertThat(output).contains(" - Requirements base directory: null");
+    }
+
+    @Test
+    void with_defined_requirements_basedir_logs_it() throws IOException {
+        Files.writeString(buildFile, """
+            serenity {
+                requirementsBaseDir = 'something'
+            }
+        """, StandardOpenOption.APPEND);
+        var result = runAggregateTask();
+
+        var output = result.getOutput();
+        assertThat(output).contains(" - Requirements base directory: something");
+    }
+
+    private BuildResult runAggregateTask() {
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments("aggregate")
+                .withPluginClasspath()
+                .build();
+    }
+}

--- a/src/test/java/net/serenitybdd/plugins/gradle/WhenRunningCheckOutcomesTask.java
+++ b/src/test/java/net/serenitybdd/plugins/gradle/WhenRunningCheckOutcomesTask.java
@@ -1,0 +1,89 @@
+package net.serenitybdd.plugins.gradle;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WhenRunningCheckOutcomesTask {
+
+    // We have to use the same build file for all tests, because serenity caches the project-directory
+    // in net.serenitybdd.model.di.ModelInfrastructure.configuration
+    @TempDir
+    static Path testProjectDir;
+    static Path buildFile;
+
+    @BeforeEach
+    void setup() throws IOException {
+        buildFile = testProjectDir.resolve("build.gradle");
+        Files.writeString(buildFile, """
+            plugins {
+                id 'net.serenity-bdd.serenity-gradle-plugin'
+            }
+        """, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    @Test
+    void without_configuration_logs_null_project_key() throws IOException {
+        Files.createDirectories(testProjectDir.resolve("target/site/serenity"));
+
+        var result = runCheckOutcomesTask();
+
+        var outcome = result.task(":checkOutcomes").getOutcome();
+        assertThat(outcome).isEqualTo(TaskOutcome.SUCCESS);
+
+        var output = result.getOutput();
+        assertThat(output).contains("Checking serenity results for ", testProjectDir.getFileName().toString(), " in directory ");
+    }
+
+    @Test
+    void with_project_key_configuration_logs_it() throws IOException {
+        Files.writeString(buildFile, """
+            serenity {
+                projectKey = 'something'
+            }
+        """, StandardOpenOption.APPEND);
+        Files.createDirectories(testProjectDir.resolve("target/site/serenity"));
+
+        var result = runCheckOutcomesTask();
+
+        var outcome = result.task(":checkOutcomes").getOutcome();
+        assertThat(outcome).isEqualTo(TaskOutcome.SUCCESS);
+
+        var output = result.getOutput();
+        assertThat(output).contains("Checking serenity results for something in directory ");
+    }
+
+    @Test
+    void without_report_directory_skips_it() throws IOException {
+        Files.deleteIfExists(testProjectDir.resolve("target/site/serenity"));
+        Files.writeString(buildFile, """
+            serenity {
+                projectKey = 'something'
+            }
+        """, StandardOpenOption.APPEND);
+
+        var result = runCheckOutcomesTask();
+
+        var outcome = result.task(":checkOutcomes").getOutcome();
+        assertThat(outcome).isEqualTo(TaskOutcome.SKIPPED);
+    }
+
+    private BuildResult runCheckOutcomesTask() {
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments("checkOutcomes")
+                .withPluginClasspath()
+                .build();
+    }
+
+}

--- a/src/test/java/net/serenitybdd/plugins/gradle/WhenRunningClearHistoryTask.java
+++ b/src/test/java/net/serenitybdd/plugins/gradle/WhenRunningClearHistoryTask.java
@@ -1,0 +1,51 @@
+package net.serenitybdd.plugins.gradle;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WhenRunningClearHistoryTask {
+
+    @TempDir
+    Path testProjectDir;
+    Path buildFile;
+
+    @BeforeEach
+    void setup() throws IOException {
+        buildFile = testProjectDir.resolve("build.gradle");
+        Files.writeString(buildFile, """
+            plugins {
+                id 'net.serenity-bdd.serenity-gradle-plugin'
+            }
+        """);
+    }
+
+    @Test
+    void without_configuration_deletes_default_history_directory() throws IOException {
+        final var historyDirectory = testProjectDir.resolve("history");
+        Files.createDirectories(historyDirectory);
+        Files.createFile(historyDirectory.resolve("dummyfile"));
+
+        var result = runClearHistoryTask();
+
+        var outcome = result.task(":clearHistory").getOutcome();
+        assertThat(outcome).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(Files.exists(historyDirectory)).isFalse();
+    }
+
+    private BuildResult runClearHistoryTask() {
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments("clearHistory")
+                .withPluginClasspath()
+                .build();
+    }
+}

--- a/src/test/java/net/serenitybdd/plugins/gradle/WhenRunningClearReportsTask.java
+++ b/src/test/java/net/serenitybdd/plugins/gradle/WhenRunningClearReportsTask.java
@@ -1,0 +1,52 @@
+package net.serenitybdd.plugins.gradle;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WhenRunningClearReportsTask {
+
+    @TempDir
+    Path testProjectDir;
+    Path buildFile;
+
+    @BeforeEach
+    void setup() throws IOException {
+        buildFile = testProjectDir.resolve("build.gradle");
+        Files.writeString(buildFile, """
+            plugins {
+                id 'net.serenity-bdd.serenity-gradle-plugin'
+            }
+        """);
+    }
+
+    @Test
+    void without_configuration_deletes_default_reports_directory() throws IOException {
+        final var reportsDirectory = testProjectDir.resolve("target/site/serenity");
+        Files.createDirectories(reportsDirectory);
+        Files.createFile(reportsDirectory.resolve("dummyfile"));
+
+        var result = runClearReportsTask();
+
+        var outcome = result.task(":clearReports").getOutcome();
+        assertThat(outcome).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(Files.exists(reportsDirectory)).isFalse();
+    }
+
+    private BuildResult runClearReportsTask() {
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments("clearReports")
+                .withPluginClasspath()
+                .build();
+    }
+}
+

--- a/src/test/java/net/serenitybdd/plugins/gradle/WhenRunningReportTask.java
+++ b/src/test/java/net/serenitybdd/plugins/gradle/WhenRunningReportTask.java
@@ -1,0 +1,47 @@
+package net.serenitybdd.plugins.gradle;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WhenRunningReportTask {
+
+    @TempDir
+    Path testProjectDir;
+    Path buildFile;
+
+    @BeforeEach
+    void setup() throws IOException {
+        buildFile = testProjectDir.resolve("build.gradle");
+        Files.writeString(buildFile, """
+            plugins {
+                id 'net.serenity-bdd.serenity-gradle-plugin'
+            }
+        """);
+    }
+
+    @Test
+    void without_configuration_logs_null_test_root() {
+        var result = runAggregateTask();
+
+        var output = result.getOutput();
+        assertThat(output).contains("Generating Additional Serenity Reports for ",
+                " to directory ",
+                Path.of("target", "site", "serenity").toString());
+    }
+
+    private BuildResult runAggregateTask() {
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments("report")
+                .withPluginClasspath()
+                .build();
+    }
+}


### PR DESCRIPTION
Since [gradle 8.1](https://docs.gradle.org/8.1/release-notes.html) the [configuration-cache](https://docs.gradle.org/current/userguide/configuration_cache.html) has become stable. This is basically the last plugin in our project that is not currently not compatible with the configuration-cache. So here is my attempt to fix that. 😄 

It required a lot of changes unfortunately. I added some tests using the `GradleRunner` and tested that it's working on our project. We are not using custom configuration though and the tests do not cover everything.

This also fixes a `ClassCastException` in the `HistoryTask` and `ClearHistoryTask` was also not working for me when the directory was not empty.