### PR TITLE
Multi module support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,13 +100,6 @@ wrapper {
 }
 
 test {
-    include '**/When*'
-    include '**/Cucumber*'
-    include '**/ScenarioLineCount*'
-    exclude '**/*$*'
-    exclude '**/integration/**'
-    exclude '**/samples/**'
-    exclude '**/*Sample*'
     maxParallelForks = Runtime.runtime.availableProcessors() * 4
     useJUnitPlatform {}
 }
@@ -115,7 +108,7 @@ test {
 configurations.all {
     resolutionStrategy {
         // fail fast on dependency convergence problems
-        //failOnVersionConflict()
+        // failOnVersionConflict()
         force "commons-collections:commons-collections:${commonsCollectionsVersion}",
                 "xml-apis:xml-apis:${xmlApiVersion}",
                 "commons-codec:commons-codec:${commonsCodecVersion}",
@@ -130,6 +123,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.2")
+    testImplementation("org.assertj:assertj-core:3.25.3")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@ serenityCoreVersion = 4.0.46
 seleniumVersion = 4.15.0
 junitVersion = 4.13.1
 logbackVersion=1.0.13
-assertjVersion = 3.25.2
 commonsCollectionsVersion = 3.2.2
 xmlApiVersion=1.4.01
 commonsCodecVersion = 1.10

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/AggregateTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/AggregateTask.groovy
@@ -51,7 +51,7 @@ abstract class AggregateTask extends SerenityAbstractTask {
 
     @TaskAction
     void aggregate() {
-        updateSystemPath()
+        updateLayoutPaths()
         def testRoot = getTestRoot().getOrNull()
         logger.lifecycle("Generating Serenity Reports")
 

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/CheckOutcomesTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/CheckOutcomesTask.groovy
@@ -27,7 +27,7 @@ abstract class CheckOutcomesTask extends SerenityAbstractTask {
 
     @TaskAction
     void checkOutcomes() {
-        updateSystemPath()
+        updateLayoutPaths()
         logger.lifecycle("Checking serenity results for ${getProjectKey().get()} in directory $reportDirectory")
         if (Files.exists(reportDirectory)) {
             def checker = new ResultChecker(reportDirectory.toFile())

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/HistoryTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/HistoryTask.groovy
@@ -29,7 +29,7 @@ abstract class HistoryTask extends SerenityAbstractTask {
 
     @TaskAction
     void history() {
-        updateSystemPath()
+        updateLayoutPaths()
         new FileSystemTestOutcomeSummaryRecorder(historyDirectory,
                 getDeletePreviousHistory().get())
                 .recordOutcomeSummariesFrom(sourceDirectory);

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/ReportTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/ReportTask.groovy
@@ -38,7 +38,7 @@ abstract class ReportTask extends SerenityAbstractTask {
 
     @TaskAction
     void report() {
-        updateSystemPath()
+        updateLayoutPaths()
         logger.lifecycle("Generating Additional Serenity Reports for ${getProjectKey().get()} to directory $reportDirectory")
         System.properties['serenity.project.key'] = getProjectKey()
         if (getTestRoot().isPresent()) {

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityAbstractTask.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityAbstractTask.groovy
@@ -1,7 +1,6 @@
 package net.serenitybdd.plugins.gradle
 
-import net.serenitybdd.core.di.SerenityInfrastructure
-import net.thucydides.model.configuration.SystemPropertiesConfiguration
+
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ProjectLayout
 
@@ -22,12 +21,7 @@ class SerenityAbstractTask extends DefaultTask {
         return Paths.get(System.getProperty("user.dir")).resolve(path)
     }
 
-    void updateSystemPath() {
-        def projectBuildDirectory = layout.projectDirectory.asFile.absolutePath
-        System.properties['project.build.directory'] = projectBuildDirectory
-        SystemPropertiesConfiguration configuration = SerenityInfrastructure.getConfiguration()
-        configuration.getEnvironmentVariables().setProperty('project.build.directory', projectBuildDirectory)
-        configuration.reloadOutputDirectory()
+    void updateLayoutPaths() {
+        SerenityPlugin.updateLayoutPaths(layout)
     }
-
 }

--- a/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPluginExtension.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPluginExtension.groovy
@@ -1,11 +1,19 @@
 package net.serenitybdd.plugins.gradle
 
-import net.serenitybdd.core.di.SerenityInfrastructure;
+import net.serenitybdd.core.di.SerenityInfrastructure
+import net.thucydides.model.configuration.SystemPropertiesConfiguration
+import net.thucydides.model.webdriver.Configuration;
 
 class SerenityPluginExtension {
-    private final def configuration = SerenityInfrastructure.getConfiguration()
-    String outputDirectory = configuration.getOutputDirectory()
-    String historyDirectory = configuration.getHistoryDirectory()
+    SerenityPluginExtension() {
+        // needs SerenityPlugin.updateLayoutPaths()
+        def configuration = SerenityInfrastructure.getConfiguration()
+        outputDirectory = configuration.getOutputDirectory()
+        historyDirectory = configuration.getHistoryDirectory()
+        println("!!!!   " + outputDirectory)
+    }
+    String outputDirectory
+    String historyDirectory
     String projectKey
     String issueTrackerUrl
     String jiraUrl

--- a/src/test/java/net/serenitybdd/plugins/gradle/ExplicitTaskDependenciesTest.java
+++ b/src/test/java/net/serenitybdd/plugins/gradle/ExplicitTaskDependenciesTest.java
@@ -1,0 +1,80 @@
+package net.serenitybdd.plugins.gradle;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExplicitTaskDependenciesTest {
+
+    @TempDir(cleanup = CleanupMode.NEVER)
+    Path testProjectDir;
+    Path buildFile;
+
+    @BeforeEach
+    void setup() throws IOException {
+        buildFile = testProjectDir.resolve("build.gradle");
+        Files.writeString(buildFile, """
+            plugins {
+                id 'java'
+                id 'net.serenity-bdd.serenity-gradle-plugin'
+            }
+            repositories {
+                mavenCentral()
+            }
+            test {
+                useJUnitPlatform {}
+            }
+            ext {
+                serenityCoreVersion = '4.0.46'
+                junitVersion = '5.10.+'
+            }
+                    
+            dependencies {
+                testImplementation "net.serenity-bdd:serenity-core:${serenityCoreVersion}",
+                        "net.serenity-bdd:serenity-junit5:${serenityCoreVersion}",
+                        "org.junit.jupiter:junit-jupiter-api:${junitVersion}",
+                        "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+            }
+        """);
+        var javaRoot = testProjectDir.resolve("src/test/java");
+        Files.createDirectories(javaRoot);
+        Files.writeString(javaRoot.resolve("NoopTest.java"), """
+            import org.junit.jupiter.api.Test;
+            import net.serenitybdd.junit5.SerenityJUnit5Extension;
+            import org.junit.jupiter.api.Test;
+            import org.junit.jupiter.api.extension.ExtendWith;
+            
+            @ExtendWith(SerenityJUnit5Extension.class)
+            class NoopTest {
+                @Test
+                void noop() {
+                }
+            }
+        """);
+    }
+
+    @Test
+    void explicitDependencyBetweenClearReportsAndCheckOutcomes() {
+        var result = runTasks("test", "checkOutcomes", "clearReports", "-i");
+        assertThat(result.getOutput().contains("BUILD SUCCESSFUL"));
+    }
+
+    private BuildResult runTasks(String... args) {
+        return GradleRunner.create()
+                .withGradleVersion("8.5")
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments(args)
+                .withPluginClasspath()
+                .build();
+    }
+}

--- a/src/test/java/net/serenitybdd/plugins/gradle/MultiModuleTest.java
+++ b/src/test/java/net/serenitybdd/plugins/gradle/MultiModuleTest.java
@@ -1,0 +1,97 @@
+package net.serenitybdd.plugins.gradle;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+public class MultiModuleTest {
+
+    @TempDir(cleanup = CleanupMode.NEVER)
+    Path testProjectDir;
+
+    List<String> subprojectNames;
+    List<Path> subprojectPaths;
+
+    @BeforeEach
+    void setup() throws IOException {
+        var ids = IntStream.rangeClosed(1, 2).boxed().toList();
+        subprojectNames = ids.stream().map(i -> "subproject-" + i).toList();
+        subprojectPaths = subprojectNames.stream().map(testProjectDir::resolve).toList();
+        var settingsFile = testProjectDir.resolve("settings.gradle");
+        var settingsContent = subprojectNames.stream().map(s -> "include '" + s + "'").reduce((a, b) -> a + "\n" + b).orElse("");
+        Files.writeString(settingsFile, settingsContent);
+        for (var s : subprojectNames) {
+            Files.createDirectories(testProjectDir.resolve(s).resolve("src/test/java"));
+            Files.writeString(testProjectDir.resolve(s).resolve("build.gradle"), """
+                        plugins {
+                            id 'java'
+                            id 'net.serenity-bdd.serenity-gradle-plugin'
+                        }
+                        repositories {
+                            mavenCentral()
+                        }
+                        test {
+                            useJUnitPlatform {}
+                        }
+                        ext {
+                            serenityCoreVersion = '4.0.46'
+                            junitVersion = '5.10.+'
+                        }
+                                
+                        dependencies {
+                            testImplementation "net.serenity-bdd:serenity-core:${serenityCoreVersion}",
+                                    "net.serenity-bdd:serenity-junit5:${serenityCoreVersion}",
+                                    "org.junit.jupiter:junit-jupiter-api:${junitVersion}",
+                                    "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+                        }
+                    """);
+            Files.writeString(testProjectDir.resolve(s).resolve("src/test/java/NoopTest.java"), """
+                        import org.junit.jupiter.api.Test;
+                        import net.serenitybdd.junit5.SerenityJUnit5Extension;
+                        import org.junit.jupiter.api.Test;
+                        import org.junit.jupiter.api.extension.ExtendWith;
+                        
+                        @ExtendWith(SerenityJUnit5Extension.class)
+                        class NoopTest {
+                            @Test
+                            void noop() {
+                            }
+                        }
+                    """);
+        }
+    }
+
+    @Test
+    void multiModulesAggregateTheReportInTheRightLocation() throws IOException {
+        var result = runTasks("test", "-i");
+        System.out.println(result.getOutput());
+        for (var path : subprojectPaths) {
+            Path report = path.resolve("target/site/serenity/index.html");
+            assertThat(report).exists();
+        }
+        assertThat(result.getOutput().contains("BUILD SUCCESSFUL"));
+    }
+
+    private BuildResult runTasks(String... args) {
+        return GradleRunner.create()
+                .withGradleVersion("8.5")
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments(args)
+                .withPluginClasspath()
+                .forwardOutput()
+                .build();
+    }
+}


### PR DESCRIPTION
To be merged after #24. 

Adds a first test case for multi module builds. Fix an issue with incorrect output dir. The test case, if run against 4.0.46, fails because all submodules (`submodule-{1,2,..}`) use the output dir of the first submodule.