### PR TITLE
Gradle plugin fix for delete stale report and no aggregate in test task

### DIFF
--- a/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -35,6 +35,7 @@ class SerenityPlugin implements Plugin<Project> {
             jiraProject = extension.jiraProject
             generateOutcomes = extension.generateOutcomes
 
+            outputs.dir(reportDirectory)
             outputs.cacheIf( { false })
         }
 
@@ -85,7 +86,8 @@ class SerenityPlugin implements Plugin<Project> {
         }
 
         project.tasks.named('test').configure {
-            finalizedBy aggregate
+            // Intentionally removed automatic report aggregation after tests
+            // finalizedBy aggregate
         }
 
         project.tasks.named('clean').configure {


### PR DESCRIPTION
Related to #33 

Resolves "Delete stale output file" and 
Intentionally removed finalizedBy aggregate in test task, to ensure separation of test and aggregate tasks